### PR TITLE
fix: capacity calculation in lib.net.assignMacs

### DIFF
--- a/lib/net.nix
+++ b/lib/net.nix
@@ -311,7 +311,7 @@ in
         assignMacs =
           base: size: reserved: hosts:
           let
-            capacity = libNet.bit.left 1 size;
+            capacity = libNet.bit.left (size - 1) 2;
             baseAsInt = libNet.net.mac.diff base "00:00:00:00:00:00";
             init = unique (
               flip map reserved (x: if builtins.typeOf x == "int" then x else libNet.net.mac.diff x base)


### PR DESCRIPTION
Hey! 

First of all, thanks to you guys for putting out this project :) I have wrangled a lot of my personal code to be compatible with this flake because I really like some of these modules!

As such, sorry for messing with what seems to be a semi-personal project, but today I noticed a strange behaviour: when I added a microvm guest to one of my hosts, I suddenly got a warning `evaluation warning: assignMacs: hash stability may be degraded since utilization is >30%`. This seemed strange to me; while I run a "respectable" number of guests on that hosts (~20), it seemed strange to me that the MAC assignment would already fail at those levels.

The description of the `lib.net.assignMacs` states to assign the address in `[base, base + 2^size)`. However, I believe that the current implementation only works in `[base, base + 2*size)`, which would also explain the evaluation warning.

If this is indeed in error, this PR would fix this issue. If not, I am very sorry for disturbing the peace here :)